### PR TITLE
lib/Makefile: set correct soname for libcryptfs-tpm2

### DIFF
--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -40,11 +40,11 @@ install: all
 	$(INSTALL) -d -m 755 $(DESTDIR)$(LIBDIR)
 	$(INSTALL) -m 755 $(LIB_NAME).a $(DESTDIR)$(LIBDIR)
 	$(INSTALL) -m 755 $(LIB_NAME).so $(DESTDIR)$(LIBDIR)/$(LIB_NAME).so.$(VERSION)
-	$(foreach x, $(LIB_NAME).so, ln -sfn $(x).$(VERSION) $(DESTDIR)$(LIBDIR)/$(patsubst %,%.$(MAJOR_VERSION).$(MINOR_VERSION),$(x)); \
-		ln -sfn $(x).$(MAJOR_VERSION).$(MINOR_VERSION) $(DESTDIR)$(LIBDIR)/$(patsubst %,%.$(MAJOR_VERSION),$(x));)
+	$(foreach x, $(LIB_NAME), ln -sfn $(x).so.$(VERSION) $(DESTDIR)$(LIBDIR)/$(patsubst %,%.so.$(MAJOR_VERSION),$(x)); \
+		ln -sfn $(x).so.$(VERSION) $(DESTDIR)$(LIBDIR)/$(patsubst %,%.so,$(x));)
 
 $(LIB_NAME).so: $(OBJS_$(LIB_NAME))
-	$(CCLD) $^ -o $@ $(CFLAGS) -shared -Wl,-soname,$(patsubst %.$(VERSION),%,$@)
+	$(CCLD) $^ -o $@ $(CFLAGS) -shared -Wl,-soname,$(patsubst %,%.$(MAJOR_VERSION),$@)
 
 $(LIB_NAME).a: $(filter-out init.o,$(OBJS_$(LIB_NAME)))
 	$(AR) rcs $@ $^


### PR DESCRIPTION
The current soname of libcryptfs-tpm2 is libcryptfs-tpm2.so:
$ readelf -d libcryptfs-tpm2.so.0.7.0 | grep SONAME
0x000000000000000e (SONAME)    Library soname: [libcryptfs-tpm2.so]

The libcryptfs-tpm2.so is a symbolic link of libcryptfs-tmp2.so.0.7.0
and it is not installed by default because it is packaged to dev
package. Then we will encounter an error when run command cryptfs-tpm2:
$ cryptfs-tpm2
cryptfs-tpm2: error while loading shared libraries: libcryptfs-tpm2.so: cannot open shared object file: No such file or directory
$ ldd cryptfs-tpm2 | grep libcryptfs-tpm2
    libcryptfs-tpm2.so => not found

Set the soname to libcryptfs-tpm2.so.$(MAJOR_VERSION) to fix the issue.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>