### PR TITLE
Revert "Revert "types: fix misspelling of TPM2_PT_TPM2_HR_PERSISTENT""

### DIFF
--- a/src/include/cryptfs_tpm2.h
+++ b/src/include/cryptfs_tpm2.h
@@ -152,7 +152,7 @@
 
 #define TPM2_PT                                 TPM_PT
 #define TPM2_PT_NONE                            TPM_PT_NONE
-#define TPM2_PT_TPM2_HR_PERSISTENT              TPM_PT_HR_PERSISTENT
+#define TPM2_PT_HR_PERSISTENT                   TPM_PT_HR_PERSISTENT
 #define TPM2_PT_LOCKOUT_INTERVAL                TPM_PT_LOCKOUT_INTERVAL
 #define TPM2_PT_LOCKOUT_COUNTER                 TPM_PT_LOCKOUT_COUNTER
 #define TPM2_PT_MAX_AUTH_FAIL                   TPM_PT_MAX_AUTH_FAIL

--- a/src/lib/capability.c
+++ b/src/lib/capability.c
@@ -50,7 +50,7 @@ capability_read_public(TPMI_DH_OBJECT handle, TPM2B_PUBLIC *public_out)
 
 	UINT32 rc = Tss2_Sys_GetCapability(cryptfs_tpm2_sys_context, NULL,
 					   TPM2_CAP_HANDLES, TPM2_HT_PERSISTENT,
-					   TPM2_PT_TPM2_HR_PERSISTENT, &more_data,
+					   TPM2_PT_HR_PERSISTENT, &more_data,
 					   &capability_data, NULL);
 	if (rc != TPM2_RC_SUCCESS) {
 		err("Unable to get the TPM persistent handles (%#x)", rc);


### PR DESCRIPTION
This reverts commit 02d5d5de36edbf1db473330a8ebd10bec6b2b82e.

The typo has been fixed in tpm2-tss 2.4.6 which is in meta-secre-core.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>