### PR TITLE
luks-setup.sh: fix --nodeps option

### DIFF
--- a/scripts/init.cryptfs
+++ b/scripts/init.cryptfs
@@ -2,7 +2,7 @@
 
 # Initramfs script called by /init
 #
-# This script is a halper used to decrypt and mount the rootfs
+# This script is a helper used to decrypt and mount the rootfs
 # encrypted with cryptfs-tpm2.
 #
 # BSD 2-clause "Simplified" License

--- a/src/luks-setup/luks-setup.sh
+++ b/src/luks-setup/luks-setup.sh
@@ -127,10 +127,10 @@ Options:
  -r|--recovery
     (Optional) Use the recovery keyslot to unlock the LUKS volume.
 
- -N|--nodeps
+ -E|--nodeps
     (Optional) Don't exit due to the unmet dependency.
 
- --I|--interactive
+ -I|--interactive
     (Optional) Prompt for a user confirmation to format the backing device.
 
  --old-lockout-auth <old lockoutAuth value>
@@ -732,7 +732,7 @@ main() {
             -r|--recovery)
                 OPT_RECOVERY=1
                 ;;
-            -N|--nodeps)
+            -E|--nodeps)
                 OPT_NO_DEPS=1
                 ;;
             -I|--interactive)


### PR DESCRIPTION
The '-N' option is already used for '--no-setup' option. Replace it with '-E'.